### PR TITLE
fix if str is null in request

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ io.sockets.on('connection', function(socket) {
 });
 
 function request(str, cb) {
+  if(!str)
+    return;
   var options = {
     host: 'api.github.com',
     path: '/markdown/raw',


### PR DESCRIPTION
Server goes down when `str` is null in request method of index.js.
