### PR TITLE
fix to send User-Agent header

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ function request(str, cb) {
     method: 'POST',
     headers: {
       'Content-length': str.length,
-      'Content-Type': 'text/plain'
+      'Content-Type': 'text/plain',
+      'User-Agent': 'markup: markdown renderer (https://github.com/Jxck/markup)'
     }
   };
 


### PR DESCRIPTION
Today's github denies api requests without any user-agent headers
